### PR TITLE
add optional groupname to source import flow

### DIFF
--- a/apps/rahat-community/src/app/beneficiary-import/beneficiary-import.controller.ts
+++ b/apps/rahat-community/src/app/beneficiary-import/beneficiary-import.controller.ts
@@ -2,12 +2,13 @@ import {
   Controller,
   Get,
   Param,
+  Query,
   HttpCode,
   HttpStatus,
   UseGuards,
 } from '@nestjs/common';
 import { BeneficiaryImportService } from './beneficiary-import.service';
-import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiTags, ApiQuery } from '@nestjs/swagger';
 import {
   ACTIONS,
   AbilitiesGuard,
@@ -27,11 +28,12 @@ export class BeneficiaryImportController {
 
   @Get(':source_uuid/import')
   @HttpCode(HttpStatus.OK)
+  @ApiQuery({ name: 'groupName', required: false, description: 'Optional group name for import' })
   @CheckAbilities({
     actions: ACTIONS.CREATE,
     subject: SUBJECTS.BENEFICIARY,
   })
-  importBySourceUUID(@Param('source_uuid') uuid: string) {
-    return this.beneficiaryImportService.importBySourceUUID(uuid);
+  importBySourceUUID(@Param('source_uuid') uuid: string, @Query('groupName') groupName?: string) {
+    return this.beneficiaryImportService.importBySourceUUID(uuid, groupName);
   }
 }

--- a/apps/rahat-community/src/app/beneficiary-import/beneficiary-import.service.ts
+++ b/apps/rahat-community/src/app/beneficiary-import/beneficiary-import.service.ts
@@ -141,7 +141,7 @@ export class BeneficiaryImportService {
 
   // ─── Group creation ──────────────────────────────────────────────────────────
 
-  async createDefaultAndImportGroup(createdBy: string) {
+  async createDefaultAndImportGroup(createdBy: string, groupName?: string) {
     this.logger.debug(
       `Ensuring default/import groups for createdBy=${createdBy}`,
     );
@@ -154,7 +154,7 @@ export class BeneficiaryImportService {
       createdBy,
     });
     const importGroup = await this.groupService.upsertByName({
-      name: `import_${formatDateAndTime(new Date())}`,
+      name: groupName ? groupName : `import_${formatDateAndTime(new Date())}`,
       autoCreated: true,
       origins: [GroupOrigins.IMPORT],
       createdBy,
@@ -391,7 +391,7 @@ export class BeneficiaryImportService {
 
   // ─── Main entry point ────────────────────────────────────────────────────────
 
-  async importBySourceUUID(sourceUUID: string) {
+  async importBySourceUUID(sourceUUID: string, groupName?: string) {
     this.logger.log(`Import request started for sourceUUID=${sourceUUID}`);
 
     const source = await this.sourceService.findOne(sourceUUID);
@@ -436,7 +436,7 @@ export class BeneficiaryImportService {
 
       // 4. Create groups
       const { defaultGroupUID, importGroupUID } =
-        await this.createDefaultAndImportGroup(source.createdBy);
+        await this.createDefaultAndImportGroup(source.createdBy, groupName);
 
       // 5. Run the atomic COPY pipeline
       this.logger.log(

--- a/apps/rahat-community/src/app/processors/beneficiary.processor.ts
+++ b/apps/rahat-community/src/app/processors/beneficiary.processor.ts
@@ -1,5 +1,10 @@
 import { Logger } from '@nestjs/common';
-import { OnQueueCompleted, OnQueueFailed, Process, Processor } from '@nestjs/bull';
+import {
+  OnQueueCompleted,
+  OnQueueFailed,
+  Process,
+  Processor,
+} from '@nestjs/bull';
 import { Job } from 'bull';
 import { JOBS, QUEUE, EVENTS } from '../../constants';
 import { EventEmitter2 } from '@nestjs/event-emitter';
@@ -21,11 +26,16 @@ export class BeneficiaryProcessor {
    * trigger a retry rather than silently completing the job.
    */
   @Process(JOBS.BENEFICIARY.IMPORT)
-  async importBeneficiary(job: Job<{ sourceUUID: string }>) {
+  async importBeneficiary(
+    job: Job<{ sourceUUID: string; groupName?: string }>,
+  ) {
     this.logger.log(
-      `Processing import job. jobId=${job.id}, sourceUUID=${job.data.sourceUUID}`,
+      `Processing import job. jobId=${job.id}, sourceUUID=${job.data.sourceUUID}, groupName=${job.data.groupName}`,
     );
-    await this.benefImportService.importBySourceUUID(job.data.sourceUUID);
+    await this.benefImportService.importBySourceUUID(
+      job.data.sourceUUID,
+      job.data.groupName,
+    );
   }
 
   @Process(JOBS.BENEFICIARY.EXPORT)

--- a/apps/rahat-community/src/app/sources/source.service.ts
+++ b/apps/rahat-community/src/app/sources/source.service.ts
@@ -28,6 +28,7 @@ import { Enums, SETTINGS_NAMES } from '@rahataid/community-tool-sdk';
 import { uploadToR2 } from '../export/helpers/r2-upload.helper';
 import { fetchSchemaFields } from '../beneficiary-import/helpers';
 import { DB_MODELS } from '../../constants';
+import { group } from 'console';
 
 export type ImportProgressStatus =
   | 'PENDING'
@@ -554,7 +555,7 @@ export class SourceService {
     // 4. Enqueue the import job
     await this.queueClient.add(
       JOBS.BENEFICIARY.IMPORT,
-      { sourceUUID: row.uuid },
+      { sourceUUID: row.uuid, groupName: data.groupName },
       QUEUE_RETRY_OPTIONS,
     );
 

--- a/libs/extentions/src/dtos/source/create-source.dto.ts
+++ b/libs/extentions/src/dtos/source/create-source.dto.ts
@@ -71,4 +71,8 @@ export class CreateSourceDto {
   })
   @IsOptional()
   createdBy?: string;
+
+  @IsOptional()
+  @IsString()
+  groupName?:string;
 }


### PR DESCRIPTION
## Summary
This PR introduces an optional groupName parameter that allows callers of the Create Source → Import flow to specify the name of the beneficiary import group.

If groupName is provided, the import will create (or reuse) a group with that exact name.
If omitted, the existing behavior—creating a timestamp‑based default import group—remains unchanged.
