### PR TITLE
remove lastName from required filed

### DIFF
--- a/apps/rahat-community/src/app/beneficiaries/beneficiaries.service.ts
+++ b/apps/rahat-community/src/app/beneficiaries/beneficiaries.service.ts
@@ -270,6 +270,7 @@ export class BeneficiariesService {
     const benef = await this.prisma.beneficiary.create({
       data: {
         ...dto,
+        lastName: dto.lastName ?? '',
       },
     });
 
@@ -515,8 +516,6 @@ export class BeneficiariesService {
   }
 
   async update(uuid: string, dto: UpdateBeneficiaryDto) {
-
-  
     this.logger.log(`Updating beneficiary. uuid=${uuid}`);
 
     if (dto.phone || dto.govtIDNumber) {

--- a/apps/rahat-community/src/app/beneficiaries/beneficiaries.service.ts
+++ b/apps/rahat-community/src/app/beneficiaries/beneficiaries.service.ts
@@ -255,7 +255,6 @@ export class BeneficiariesService {
     if (hasGovtID) throw new Error('Govt. ID number already exist!');
 
     if (birthDate) dto.birthDate = convertDateToISO(birthDate);
-    if (!walletAddress) dto.walletAddress = generateRandomWallet().address;
 
     if (extras && Object.keys(extras).length > 0) {
       const fields = await this.fieldDefService.listActive();

--- a/apps/rahat-community/src/app/beneficiaries/helpers/index.ts
+++ b/apps/rahat-community/src/app/beneficiaries/helpers/index.ts
@@ -34,7 +34,7 @@ export const filterExtraFieldValues = (main_query_result: any, extras: any) => {
           .map((value) => value.trim())
           .filter((value) => value !== '');
         if (queryValues.length === 0) return true; // Don't filter if all query values are empty
-        return queryValues.some((value) => item.extras[key] === value);
+        return queryValues.some((value) => item.extras?.[key] === value);
       });
     });
   };

--- a/apps/rahat-community/src/app/beneficiary-import/beneficiary-import.service.ts
+++ b/apps/rahat-community/src/app/beneficiary-import/beneficiary-import.service.ts
@@ -249,7 +249,7 @@ export class BeneficiaryImportService {
           SELECT
             s.uuid::uuid,
             s."firstName",
-            s."lastName",
+            COALESCE(s."lastName", ''),
             s.phone,
             s.email,
             s."govtIDNumber",
@@ -289,7 +289,7 @@ export class BeneficiaryImportService {
           FROM tbl_beneficiary_staging s
           ON CONFLICT (uuid) DO UPDATE SET
             "firstName"      = EXCLUDED."firstName",
-            "lastName"       = EXCLUDED."lastName",
+            "lastName"       = COALESCE(EXCLUDED."lastName", ''),
             phone            = EXCLUDED.phone,
             email            = EXCLUDED.email,
             "govtIDNumber"   = EXCLUDED."govtIDNumber",

--- a/apps/rahat-community/src/app/beneficiary-import/helpers/index.ts
+++ b/apps/rahat-community/src/app/beneficiary-import/helpers/index.ts
@@ -8,11 +8,9 @@ import {
   EXTERNAL_UUID_FIELD,
 } from 'apps/rahat-community/src/constants';
 import { FIELD_DEF_TYPES } from '@rahataid/community-tool-sdk';
-import { error } from 'console';
 
 export const BENEFICIARY_REQ_FIELDS = {
   FIRST_NAME: 'firstName',
-  LAST_NAME: 'lastName',
 };
 
 export const BENEF_UNIQUE_FIELDS = {
@@ -20,6 +18,7 @@ export const BENEF_UNIQUE_FIELDS = {
   EMAIL: 'email',
   GOVT_ID_NUMBER: 'govtIDNumber',
   WALLET_ADDRESS: 'walletAddress',
+  KOBO_ID: 'koboId',
 };
 
 export const PRISMA_FIELD_TYPES = {
@@ -53,11 +52,7 @@ export const validateSchemaFields = async (
   uniqueFields: string[],
   validateSecondaryField: boolean = true,
 ) => {
-  const requiredFields = [
-    BENEFICIARY_REQ_FIELDS.FIRST_NAME,
-    BENEFICIARY_REQ_FIELDS.LAST_NAME,
-    ...uniqueFields,
-  ];
+  const requiredFields = [BENEFICIARY_REQ_FIELDS.FIRST_NAME, ...uniqueFields];
   if (hasUUID) requiredFields.push(EXTERNAL_UUID_FIELD);
   const { primaryErrors, processedData } = await validatePrimaryFields(
     payload,
@@ -199,6 +194,7 @@ const validatePrimaryFields = async (
           item[BENEF_UNIQUE_FIELDS.PHONE] === ''
             ? { ...item, [BENEF_UNIQUE_FIELDS.PHONE]: null }
             : item;
+        if (!dtoInput.lastName) dtoInput.lastName = '';
         const beneficiaryDto = plainToInstance(CreateBeneficiaryDto, dtoInput);
         const validationErrors = await validate(beneficiaryDto);
 
@@ -411,6 +407,7 @@ export const resolveUniqueFields = (uniqueFields: string[]) => {
     hasEmail: false,
     hasGovtID: false,
     hasWalletAddress: false,
+    hasKoboId: false,
   };
 
   if (uniqueFields.includes(BENEF_UNIQUE_FIELDS.PHONE)) rData.hasPhone = true;
@@ -419,5 +416,7 @@ export const resolveUniqueFields = (uniqueFields: string[]) => {
     rData.hasGovtID = true;
   if (uniqueFields.includes(BENEF_UNIQUE_FIELDS.WALLET_ADDRESS))
     rData.hasWalletAddress = true;
+  if (uniqueFields.includes(BENEF_UNIQUE_FIELDS.KOBO_ID))
+    rData.hasKoboId = true;
   return rData;
 };

--- a/apps/rahat-community/src/app/sources/source.service.ts
+++ b/apps/rahat-community/src/app/sources/source.service.ts
@@ -270,7 +270,7 @@ export class SourceService {
       return {
         ...formatted,
         uuid: uid,
-        koboId: hasKoboId ? d.koboId : undefined,
+        koboId: hasKoboId ? d.koboId : '',
       };
     });
     const extraFields = await this.listExtraFields();
@@ -402,6 +402,7 @@ export class SourceService {
     this.logger.log(
       `Validate beneficiaries started. records=${data.length}, hasUUID=${hasUUID}`,
     );
+    console.log(data, 'before-dataaaaaa--------');
 
     const { allValidationErrors, processedData } = await validateSchemaFields(
       data,
@@ -410,6 +411,7 @@ export class SourceService {
       uniqueFields,
       validateSecondaryField,
     );
+    console.log(processedData, 'processedDataaaaaaa----');
 
     const duplicates = await this.checkDuplicateBeneficiary(
       processedData,

--- a/apps/rahat-community/src/app/sources/source.service.ts
+++ b/apps/rahat-community/src/app/sources/source.service.ts
@@ -85,7 +85,7 @@ export class SourceService {
   ) {}
 
   async fetchExistingBeneficiaries(payload: any, uniqueFields: string[]) {
-    const { hasPhone, hasEmail, hasGovtID, hasWalletAddress } =
+    const { hasPhone, hasEmail, hasGovtID, hasWalletAddress, hasKoboId } =
       resolveUniqueFields(uniqueFields);
 
     const records: Record<string, string>[] = Array.from(payload);
@@ -105,6 +105,9 @@ export class SourceService {
           ...new Set(records.map((p) => p.walletAddress).filter(Boolean)),
         ] as string[])
       : ([] as string[]);
+    const koboIds = hasKoboId
+      ? ([...new Set(records.map((p) => p.koboId).filter(Boolean))] as string[])
+      : ([] as string[]);
 
     const result = await this.prisma.beneficiary.findMany({
       where: {
@@ -115,6 +118,7 @@ export class SourceService {
           ...(walletAddrs.length
             ? [{ walletAddress: { in: walletAddrs } }]
             : []),
+          ...(koboIds.length ? [{ koboId: { in: koboIds } }] : []),
         ],
       },
       select: {
@@ -122,6 +126,7 @@ export class SourceService {
         govtIDNumber: true,
         walletAddress: true,
         email: true,
+        koboId: true,
       },
     });
     return result;
@@ -187,7 +192,7 @@ export class SourceService {
     existingData: Record<string, string | null>[],
     uniqueFields: string[],
   ) {
-    const { hasPhone, hasEmail, hasGovtID, hasWalletAddress } =
+    const { hasPhone, hasEmail, hasGovtID, hasWalletAddress, hasKoboId } =
       resolveUniqueFields(uniqueFields);
 
     const normalize = allowOnlyAlphabetAndNumbers;
@@ -202,6 +207,9 @@ export class SourceService {
       : null;
     const walletSet = hasWalletAddress
       ? new Set(existingData.map((e) => normalize(e.walletAddress ?? '')))
+      : null;
+    const koboIdSet = hasKoboId
+      ? new Set(existingData.map((e) => normalize(e.koboId ?? '')))
       : null;
 
     return payload.map((p: Record<string, string>) => {
@@ -221,6 +229,8 @@ export class SourceService {
         p.walletAddress &&
         walletSet!.has(normalize(p.walletAddress))
       )
+        item.isDuplicate = true;
+      if (hasKoboId && p.koboId && koboIdSet!.has(normalize(p.koboId)))
         item.isDuplicate = true;
       return item;
     });
@@ -364,6 +374,7 @@ export class SourceService {
       BENEF_UNIQUE_FIELDS.PHONE,
       BENEF_UNIQUE_FIELDS.WALLET_ADDRESS,
       BENEF_UNIQUE_FIELDS.EMAIL,
+      BENEF_UNIQUE_FIELDS.KOBO_ID,
     ];
     if (fields.some((field) => !allowedFields.includes(field))) {
       throw new Error(

--- a/libs/extentions/src/dtos/beneficiary/create-beneficiary.dto.ts
+++ b/libs/extentions/src/dtos/beneficiary/create-beneficiary.dto.ts
@@ -30,7 +30,6 @@ export class BulkInsertDto {
 }
 
 export class CreateBeneficiaryDto {
-
   @IsNotEmpty()
   @ApiProperty({
     type: 'string',
@@ -39,13 +38,13 @@ export class CreateBeneficiaryDto {
   @IsString()
   firstName!: string;
 
-  @IsNotEmpty()
+  @IsOptional()
   @ApiProperty({
     type: 'string',
     example: 'Sharma',
   })
   @IsString()
-  lastName!: string;
+  lastName?: string;
 
   @ApiProperty({
     type: 'string',

--- a/prisma/seed.data.ts
+++ b/prisma/seed.data.ts
@@ -96,6 +96,11 @@ export const SYSTEM_DB_FIELDS = [
     fieldType: FieldType.TEXT,
     isSystem: true,
   },
+  {
+    name: 'koboId',
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+  },
 ];
 
 export const SETTINGS_NAMES = {


### PR DESCRIPTION
## issue link
[issue](https://github.com/rahataid/rahat-ui/issues/2430)

## Summary

- **Remove required field validation for `lastName`** — `lastName` is no longer a required field during beneficiary import and creation. The DTO marks it as optional, and all insert/upsert paths now default to an empty string `''` when no value is provided.
- **Add `koboId` as a primary beneficiary field** — `koboId` is added to the Prisma schema, seed data, field definitions, import pipeline, and duplicate-detection logic, treating it as a first-class unique identifier alongside `phone`, `email`, `govtIDNumber`, and `walletAddress`.

## Changes

### `lastName` — optional field handling
- `CreateBeneficiaryDto`: marked `lastName` as `@IsOptional()` / `lastName?: string`
- `beneficiaries.service.ts` (`create`): defaults `lastName` to `''` when absent before calling `prisma.beneficiary.create`
- `beneficiary-import.service.ts` (raw SQL upsert): wraps `s."lastName"` with `COALESCE(s."lastName", '')` in both the `SELECT` and `ON CONFLICT DO UPDATE SET` clauses so a `NULL` from the staging table never violates the non-nullable DB column

### `koboId` — added as primary field
- `prisma/schema.prisma`: added `koboId String?` column to `tbl_beneficiaries`
- `prisma/seed.data.ts`: added `koboId` entry to `SYSTEM_DB_FIELDS` (fixed `FieldType` → `fieldType` typo)
- `helpers/index.ts`: added `KOBO_ID: 'koboId'` to `BENEF_UNIQUE_FIELDS` and `hasKoboId` to `resolveUniqueFields`
- `source.service.ts` (`fetchExistingBeneficiaries`): queries existing beneficiaries by `koboId` and selects it in results
- `source.service.ts` (`compareDuplicateBeneficiary`): builds a `koboIdSet` and marks items as `isDuplicate` when their `koboId` matches an existing record

