### PR TITLE
Remove special character

### DIFF
--- a/apps/rahat-community/src/app/sources/source.service.ts
+++ b/apps/rahat-community/src/app/sources/source.service.ts
@@ -263,8 +263,8 @@ export class SourceService {
     );
 
     const payloadWithUUID = data.map((d: any) => {
-      if (d.govtIDNumber)
-        d.govtIDNumber = allowOnlyAlphabetAndNumbers(d.govtIDNumber.toString());
+      if (d.govtIDNumber) d.govtIDNumber = d.govtIDNumber.toString();
+
       if (d.phone) d.phone = sanitizePhoneNumber(d.phone.toString());
       Object.keys(d).forEach((key) => {
         const k = key.toLowerCase();

--- a/apps/rahat-community/src/app/sources/source.service.ts
+++ b/apps/rahat-community/src/app/sources/source.service.ts
@@ -258,8 +258,8 @@ export class SourceService {
     );
 
     const payloadWithUUID = data.map((d: any) => {
-      if (d.govtIDNumber) d.govtIDNumber = d.govtIDNumber.toString();
-      if (d.phone) d.phone = d.phone.toString();
+      if (d.govtIDNumber) d.govtIDNumber = allowOnlyAlphabetAndNumbers(d.govtIDNumber.toString());
+      if (d.phone) d.phone = allowOnlyAlphabetAndNumbers(d.phone.toString());
       const formatted = formatEnumFieldValues(d);
       const hasKoboId = d.koboId != null && d.koboId !== '';
       const uid = hasUUID

--- a/apps/rahat-community/src/app/sources/source.service.ts
+++ b/apps/rahat-community/src/app/sources/source.service.ts
@@ -22,7 +22,11 @@ import {
   validateSchemaFields,
 } from '../beneficiary-import/helpers';
 import { FieldDefinitionsService } from '../field-definitions/field-definitions.service';
-import { parseIsoDateToString, allowOnlyAlphabetAndNumbers } from '../utils';
+import {
+  parseIsoDateToString,
+  allowOnlyAlphabetAndNumbers,
+  sanitizePhoneNumber,
+} from '../utils';
 import { paginate } from '../utils/paginate';
 import { Enums, SETTINGS_NAMES } from '@rahataid/community-tool-sdk';
 import { uploadToR2 } from '../export/helpers/r2-upload.helper';
@@ -258,8 +262,9 @@ export class SourceService {
     );
 
     const payloadWithUUID = data.map((d: any) => {
-      if (d.govtIDNumber) d.govtIDNumber = allowOnlyAlphabetAndNumbers(d.govtIDNumber.toString());
-      if (d.phone) d.phone = allowOnlyAlphabetAndNumbers(d.phone.toString());
+      if (d.govtIDNumber) d.govtIDNumber = d.govtIDNumber.toString();
+
+      if (d.phone) d.phone = sanitizePhoneNumber(d.phone.toString());
       const formatted = formatEnumFieldValues(d);
       const hasKoboId = d.koboId != null && d.koboId !== '';
       const uid = hasUUID
@@ -402,7 +407,6 @@ export class SourceService {
     this.logger.log(
       `Validate beneficiaries started. records=${data.length}, hasUUID=${hasUUID}`,
     );
-    console.log(data, 'before-dataaaaaa--------');
 
     const { allValidationErrors, processedData } = await validateSchemaFields(
       data,
@@ -411,7 +415,6 @@ export class SourceService {
       uniqueFields,
       validateSecondaryField,
     );
-    console.log(processedData, 'processedDataaaaaaa----');
 
     const duplicates = await this.checkDuplicateBeneficiary(
       processedData,

--- a/apps/rahat-community/src/app/sources/source.service.ts
+++ b/apps/rahat-community/src/app/sources/source.service.ts
@@ -26,6 +26,7 @@ import {
   parseIsoDateToString,
   allowOnlyAlphabetAndNumbers,
   sanitizePhoneNumber,
+  sanitizeDigitsOnly,
 } from '../utils';
 import { paginate } from '../utils/paginate';
 import { Enums, SETTINGS_NAMES } from '@rahataid/community-tool-sdk';
@@ -262,9 +263,20 @@ export class SourceService {
     );
 
     const payloadWithUUID = data.map((d: any) => {
-      if (d.govtIDNumber) d.govtIDNumber = d.govtIDNumber.toString();
-
+      if (d.govtIDNumber)
+        d.govtIDNumber = allowOnlyAlphabetAndNumbers(d.govtIDNumber.toString());
       if (d.phone) d.phone = sanitizePhoneNumber(d.phone.toString());
+      Object.keys(d).forEach((key) => {
+        const k = key.toLowerCase();
+        const isBankNumericField =
+          k.includes('bank') &&
+          (k.includes('ac_number') ||
+            k.includes('account_number') ||
+            k.includes('_no'));
+        if (isBankNumericField && d[key]) {
+          d[key] = sanitizeDigitsOnly(d[key].toString());
+        }
+      });
       const formatted = formatEnumFieldValues(d);
       const hasKoboId = d.koboId != null && d.koboId !== '';
       const uid = hasUUID

--- a/apps/rahat-community/src/app/utils/index.ts
+++ b/apps/rahat-community/src/app/utils/index.ts
@@ -56,10 +56,10 @@ export const allowOnlyAlphabetAndNumbers = (inputString: string) => {
   return result;
 };
 
-// Strips all non-digit characters, returns digits as string (for fields like bank_ac_number)
+// Strips special characters but keeps alphanumeric — handles bank account numbers that contain letters
 export const sanitizeDigitsOnly = (value: string): string => {
   if (!value) return '';
-  return value.replace(/[^0-9]/g, '');
+  return value.replace(/[^a-zA-Z0-9]/g, '');
 };
 
 // Keeps leading + (country code) and digits only — strips dashes, spaces, parens, etc.

--- a/apps/rahat-community/src/app/utils/index.ts
+++ b/apps/rahat-community/src/app/utils/index.ts
@@ -56,6 +56,15 @@ export const allowOnlyAlphabetAndNumbers = (inputString: string) => {
   return result;
 };
 
+// Keeps leading + (country code) and digits only — strips dashes, spaces, parens, etc.
+export const sanitizePhoneNumber = (phone: string) => {
+  if (!phone) return '';
+  const trimmed = phone.trim();
+  const hasPlus = trimmed.startsWith('+');
+  const digits = trimmed.replace(/[^0-9]/g, '');
+  return hasPlus ? `+${digits}` : digits;
+};
+
 export const getBaseUrl = (url: string) => {
   if (!url) return '';
   const parsedUrl = new URL(url);

--- a/apps/rahat-community/src/app/utils/index.ts
+++ b/apps/rahat-community/src/app/utils/index.ts
@@ -56,6 +56,12 @@ export const allowOnlyAlphabetAndNumbers = (inputString: string) => {
   return result;
 };
 
+// Strips all non-digit characters, returns digits as string (for fields like bank_ac_number)
+export const sanitizeDigitsOnly = (value: string): string => {
+  if (!value) return '';
+  return value.replace(/[^0-9]/g, '');
+};
+
 // Keeps leading + (country code) and digits only — strips dashes, spaces, parens, etc.
 export const sanitizePhoneNumber = (phone: string) => {
   if (!phone) return '';


### PR DESCRIPTION
[issue](https://github.com/rahataid/rahat-ui/issues/2459)

# Summary

This PR introduces input sanitization for phone numbers and bank account numbers before validation during beneficiary import.

### What changed

- Added `sanitizePhoneNumber` utility to preserve the `+` country code prefix while removing special characters (spaces, dashes, parentheses) before validation.
  - Example: `+977-9841783733` → `+9779841783733`
- Added `sanitizeDigitsOnly` utility to remove all non-digit characters from numeric string fields such as:
  - `bank_ac_number`
  - `bank_account_number`
  - Other supported bank account number field variations
- All sanitization is performed in `create()` within `source.service.ts` before data is passed to `validateSchemaFields`, keeping input normalization centralized.
- Bank account fields are detected using keyword matching (`bank` + `ac_number` / `account_number` / `_no`) while explicitly excluding name fields such as `bank_ac_name`.

---

# Files Changed

### `apps/rahat-community/src/app/utils/index.ts`
- Added `sanitizePhoneNumber`
- Added `sanitizeDigitsOnly`

### `apps/rahat-community/src/app/sources/source.service.ts`
- Applied sanitization to:
  - Phone numbers
  - Bank account number fields

---

# Test Plan

## ✅ Phone Number

- [ ] Import with `+977-9841783733`
  - Expected: Passes validation and is stored as `+9779841783733`

- [ ] Import with `+977 9841783733`
  - Expected: Passes validation and is stored as `+9779841783733`

- [ ] Import with an invalid phone number (without country code)
  - Expected: Validation fails

## ✅ Bank Account Number

- [ ] Import with `bank_ac_number = 0010-055573-200018`
  - Expected: Stored as `0010055573200018`

- [ ] Import with `bank_account_number = 0010 055573 200018`
  - Expected: Stored as `0010055573200018`

- [ ] Import with `bank_ac_name = John Doe`
  - Expected: Value remains unchanged (name fields are not sanitized)